### PR TITLE
added GetHeader method

### DIFF
--- a/s3/bucket.go
+++ b/s3/bucket.go
@@ -290,14 +290,14 @@ func (b *bucket) StoreObject(key string, data []byte) error {
 	httpReq := &http.Request{
 		Verb: "PUT",
 		Path: fmt.Sprintf("/%s/%s", b.name, key),
-		Body: data,
 		Headers: map[string]string{
 			"Date": b.clock.Now().UTC().Format(sys_time.RFC1123),
 		},
+		Body: bytes.NewBuffer(data),
 	}
 
 	// Add a Content-MD5 header, as advised in the Amazon docs.
-	if err := addMd5Header(httpReq, httpReq.Body); err != nil {
+	if err := addMd5Header(httpReq, data); err != nil {
 		return err
 	}
 
@@ -343,7 +343,7 @@ func (b *bucket) DeleteObject(key string) error {
 	}
 
 	// Add a Content-MD5 header, as advised in the Amazon docs.
-	if err := addMd5Header(httpReq, httpReq.Body); err != nil {
+	if err := addMd5Header(httpReq, []byte{}); err != nil {
 		return err
 	}
 

--- a/s3/bucket_test.go
+++ b/s3/bucket_test.go
@@ -26,6 +26,8 @@ import (
 	. "github.com/jacobsa/oglematchers"
 	"github.com/jacobsa/oglemock"
 	. "github.com/jacobsa/ogletest"
+	"io"
+	"io/ioutil"
 	sys_http "net/http"
 	"strings"
 	"testing"
@@ -78,6 +80,10 @@ func (t *bucketTest) SetUp(i *TestInfo) {
 
 	t.bucket, err = openBucket("some.bucket", t.httpConn, t.signer, t.clock)
 	AssertEq(nil, err)
+}
+
+func stringReadCloser(s string) io.ReadCloser {
+	return ioutil.NopCloser(strings.NewReader(s))
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -227,7 +233,7 @@ func (t *GetObjectTest) ServerReturnsError() {
 	// Conn
 	resp := &http.Response{
 		StatusCode: 500,
-		Body:       []byte("taco"),
+		Body:       stringReadCloser("taco"),
 	}
 
 	ExpectCall(t.httpConn, "SendRequest")(Any()).
@@ -251,7 +257,7 @@ func (t *GetObjectTest) ReturnsResponseBody() {
 	// Conn
 	resp := &http.Response{
 		StatusCode: 200,
-		Body:       []byte("taco"),
+		Body:       stringReadCloser("taco"),
 	}
 
 	ExpectCall(t.httpConn, "SendRequest")(Any()).
@@ -411,7 +417,7 @@ func (t *GetHeaderTest) ServerReturnsError() {
 	// Conn
 	resp := &http.Response{
 		StatusCode: 500,
-		Body:       []byte("taco"),
+		Body:       stringReadCloser("taco"),
 	}
 
 	ExpectCall(t.httpConn, "SendRequest")(Any()).
@@ -607,7 +613,7 @@ func (t *StoreObjectTest) ServerReturnsError() {
 	// Conn
 	resp := &http.Response{
 		StatusCode: 500,
-		Body:       []byte("taco"),
+		Body:       stringReadCloser("taco"),
 	}
 
 	ExpectCall(t.httpConn, "SendRequest")(Any()).
@@ -632,7 +638,7 @@ func (t *StoreObjectTest) ServerSaysOkay() {
 	// Conn
 	resp := &http.Response{
 		StatusCode: 200,
-		Body:       []byte("taco"),
+		Body:       stringReadCloser("taco"),
 	}
 
 	ExpectCall(t.httpConn, "SendRequest")(Any()).
@@ -791,7 +797,7 @@ func (t *DeleteObjectTest) ServerReturnsError() {
 	// Conn
 	resp := &http.Response{
 		StatusCode: 500,
-		Body:       []byte("taco"),
+		Body:       stringReadCloser("taco"),
 	}
 
 	ExpectCall(t.httpConn, "SendRequest")(Any()).
@@ -815,7 +821,7 @@ func (t *DeleteObjectTest) ServerReturnsNoContent() {
 	// Conn
 	resp := &http.Response{
 		StatusCode: 204,
-		Body:       []byte("taco"),
+		Body:       stringReadCloser("taco"),
 	}
 
 	ExpectCall(t.httpConn, "SendRequest")(Any()).
@@ -991,7 +997,7 @@ func (t *ListKeysTest) ServerReturnsError() {
 	// Conn
 	resp := &http.Response{
 		StatusCode: 500,
-		Body:       []byte("taco"),
+		Body:       stringReadCloser("taco"),
 	}
 
 	ExpectCall(t.httpConn, "SendRequest")(Any()).
@@ -1015,7 +1021,7 @@ func (t *ListKeysTest) ResponseBodyIsJunk() {
 	// Conn
 	resp := &http.Response{
 		StatusCode: 200,
-		Body:       []byte("taco"),
+		Body:       stringReadCloser("taco"),
 	}
 
 	ExpectCall(t.httpConn, "SendRequest")(Any()).
@@ -1038,7 +1044,7 @@ func (t *ListKeysTest) WrongRootTag() {
 	// Conn
 	resp := &http.Response{
 		StatusCode: 200,
-		Body: []byte(`
+		Body: stringReadCloser(`
 			<?xml version="1.0" encoding="UTF-8"?>
 			<FooBar xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
 				<Contents>
@@ -1067,7 +1073,7 @@ func (t *ListKeysTest) ResponseContainsNoKeys() {
 	// Conn
 	resp := &http.Response{
 		StatusCode: 200,
-		Body: []byte(`
+		Body: stringReadCloser(`
 			<?xml version="1.0" encoding="UTF-8"?>
 			<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
 			</ListBucketResult>`),
@@ -1093,7 +1099,7 @@ func (t *ListKeysTest) ResponseContainsSomeKeys() {
 	// Conn
 	resp := &http.Response{
 		StatusCode: 200,
-		Body: []byte(`
+		Body: stringReadCloser(`
 			<?xml version="1.0" encoding="UTF-8"?>
 			<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
 				<Contents>

--- a/s3/bucket_test.go
+++ b/s3/bucket_test.go
@@ -539,7 +539,11 @@ func (t *StoreObjectTest) CallsSigner() {
 	ExpectEq("/some.bucket/foo/bar/baz", httpReq.Path)
 	ExpectEq("Mon, 18 Mar 1985 15:33:17 UTC", httpReq.Headers["Date"])
 	ExpectEq(computeBase64Md5(data), httpReq.Headers["Content-MD5"])
-	ExpectThat(httpReq.Body, DeepEquals(data))
+
+	body, err := ioutil.ReadAll(httpReq.Body)
+	ExpectEq(nil, err)
+
+	ExpectThat(body, DeepEquals(data))
 }
 
 func (t *StoreObjectTest) SignerReturnsError() {

--- a/s3/http/conn.go
+++ b/s3/http/conn.go
@@ -18,7 +18,6 @@ package http
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 )
@@ -89,18 +88,11 @@ func (c *conn) SendRequest(r *Request) (resp *Response, err error) {
 		return
 	}
 
-	// Make sure the body reader is closed no matter how we exit.
-	defer sysResp.Body.Close()
-
 	// Convert the response.
 	resp = &Response{
 		StatusCode: sysResp.StatusCode,
 		Header:     sysResp.Header,
-	}
-
-	if resp.Body, err = ioutil.ReadAll(sysResp.Body); err != nil {
-		err = &Error{"ioutil.ReadAll", err}
-		return
+		Body:       sysResp.Body,
 	}
 
 	return

--- a/s3/http/conn.go
+++ b/s3/http/conn.go
@@ -16,7 +16,6 @@
 package http
 
 import (
-	"bytes"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -70,7 +69,7 @@ func (c *conn) SendRequest(r *Request) (resp *Response, err error) {
 	urlStr := url.String()
 
 	// Create a request to the system HTTP library.
-	sysReq, err := http.NewRequest(r.Verb, urlStr, bytes.NewBuffer(r.Body))
+	sysReq, err := http.NewRequest(r.Verb, urlStr, r.Body)
 	if err != nil {
 		err = &Error{"http.NewRequest", err}
 		return

--- a/s3/http/conn.go
+++ b/s3/http/conn.go
@@ -95,6 +95,7 @@ func (c *conn) SendRequest(r *Request) (resp *Response, err error) {
 	// Convert the response.
 	resp = &Response{
 		StatusCode: sysResp.StatusCode,
+		Header:     sysResp.Header,
 	}
 
 	if resp.Body, err = ioutil.ReadAll(sysResp.Body); err != nil {

--- a/s3/http/conn_test.go
+++ b/s3/http/conn_test.go
@@ -289,7 +289,10 @@ func (t *ConnTest) ReturnsBody() {
 	resp, err := conn.SendRequest(req)
 	AssertEq(nil, err)
 
-	ExpectThat(resp.Body, DeepEquals(t.handler.body))
+	body, err := resp.ReadBody()
+	AssertEq(nil, err)
+
+	ExpectThat(body, DeepEquals(t.handler.body))
 }
 
 func (t *ConnTest) ServerReturnsEmptyBody() {
@@ -311,7 +314,10 @@ func (t *ConnTest) ServerReturnsEmptyBody() {
 	resp, err := conn.SendRequest(req)
 	AssertEq(nil, err)
 
-	ExpectThat(resp.Body, ElementsAre())
+	body, err := resp.ReadBody()
+	AssertEq(nil, err)
+
+	ExpectThat(body, ElementsAre())
 }
 
 func (t *ConnTest) HttpsAllowed() {

--- a/s3/http/request.go
+++ b/s3/http/request.go
@@ -15,6 +15,10 @@
 
 package http
 
+import (
+	"io"
+)
+
 // An HTTP request to S3.
 type Request struct {
 	// The HTTP verb; e.g. "PUT" or "GET".
@@ -42,5 +46,5 @@ type Request struct {
 	Headers map[string]string
 
 	// The body of the request.
-	Body []byte
+	Body io.Reader
 }

--- a/s3/http/response.go
+++ b/s3/http/response.go
@@ -15,10 +15,17 @@
 
 package http
 
+import (
+	"net/http"
+)
+
 // An HTTP response from S3.
 type Response struct {
 	// The HTTP status code, e.g. 200 or 404.
 	StatusCode int
+
+	// The response headers. e.g. x-amz-expiration
+	Header http.Header
 
 	// The response body. This is the empty slice if the body was empty.
 	Body []byte

--- a/s3/http/response.go
+++ b/s3/http/response.go
@@ -16,6 +16,8 @@
 package http
 
 import (
+	"io"
+	"io/ioutil"
 	"net/http"
 )
 
@@ -27,6 +29,15 @@ type Response struct {
 	// The response headers. e.g. x-amz-expiration
 	Header http.Header
 
-	// The response body. This is the empty slice if the body was empty.
-	Body []byte
+	// The response body.
+	Body io.ReadCloser
+}
+
+func (resp *Response) ReadBody() (body []byte, err error) {
+	defer resp.Body.Close()
+	body, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		err = &Error{"ioutil.ReadAll", err}
+	}
+	return
 }

--- a/s3/integration_test/tests.go
+++ b/s3/integration_test/tests.go
@@ -151,6 +151,10 @@ func (t *BucketTest) InvalidUtf8Key() {
 	_, err = t.bucket.GetObject(key)
 	ExpectThat(err, Error(HasSubstr("UTF-8")))
 
+	// Head
+	_, err = t.bucket.GetHeader(key)
+	ExpectThat(err, Error(HasSubstr("UTF-8")))
+
 	// Delete
 	err = t.bucket.DeleteObject(key)
 	ExpectThat(err, Error(HasSubstr("UTF-8")))
@@ -171,6 +175,11 @@ func (t *BucketTest) LongKey() {
 
 	// Get
 	_, err = t.bucket.GetObject(key)
+	ExpectThat(err, Error(HasSubstr("1024")))
+	ExpectThat(err, Error(HasSubstr("bytes")))
+
+	// Head
+	_, err = t.bucket.GetHeader(key)
 	ExpectThat(err, Error(HasSubstr("1024")))
 	ExpectThat(err, Error(HasSubstr("bytes")))
 
@@ -197,6 +206,10 @@ func (t *BucketTest) NullByteInKey() {
 	_, err = t.bucket.GetObject(key)
 	ExpectThat(err, Error(HasSubstr("U+0000")))
 
+	// Header
+	_, err = t.bucket.GetHeader(key)
+	ExpectThat(err, Error(HasSubstr("U+0000")))
+
 	// Delete
 	err = t.bucket.DeleteObject(key)
 	ExpectThat(err, Error(HasSubstr("U+0000")))
@@ -217,6 +230,11 @@ func (t *BucketTest) NonGraphicalCharacterInKey() {
 
 	// Get
 	_, err = t.bucket.GetObject(key)
+	ExpectThat(err, Error(HasSubstr("codepoint")))
+	ExpectThat(err, Error(HasSubstr("U+0008")))
+
+	// Header
+	_, err = t.bucket.GetHeader(key)
 	ExpectThat(err, Error(HasSubstr("codepoint")))
 	ExpectThat(err, Error(HasSubstr("U+0008")))
 
@@ -241,6 +259,10 @@ func (t *BucketTest) EmptyKey() {
 
 	// Get
 	_, err = t.bucket.GetObject(key)
+	ExpectThat(err, Error(HasSubstr("empty")))
+
+	// Header
+	_, err = t.bucket.GetHeader(key)
 	ExpectThat(err, Error(HasSubstr("empty")))
 
 	// Delete
@@ -270,6 +292,11 @@ func (t *BucketTest) StoreThenGetEmptyObject() {
 	returnedData, err := t.bucket.GetObject(key)
 	AssertEq(nil, err)
 	ExpectThat(returnedData, DeepEquals(data))
+
+	// Head
+	header, err := t.bucket.GetHeader(key)
+	AssertEq(nil, err)
+	ExpectNe(header.Get("X-Amz-Request-Id"), "")
 }
 
 func (t *BucketTest) StoreThenGetNonEmptyObject() {
@@ -286,6 +313,11 @@ func (t *BucketTest) StoreThenGetNonEmptyObject() {
 	returnedData, err := t.bucket.GetObject(key)
 	AssertEq(nil, err)
 	ExpectThat(returnedData, DeepEquals(data))
+
+	// Head
+	header, err := t.bucket.GetHeader(key)
+	AssertEq(nil, err)
+	ExpectNe(header.Get("X-Amz-Request-Id"), "")
 }
 
 func (t *BucketTest) OverwriteObject() {

--- a/s3/integration_test/tests.go
+++ b/s3/integration_test/tests.go
@@ -458,6 +458,7 @@ func (t *BucketTest) ListManyKeys() {
 	// Create them.
 	err = runForRange(numKeys, func(i int) error {
 		key := allKeys[i]
+		//		println(i)
 		t.ensureDeleted(key)
 		return t.bucket.StoreObject(key, []byte{})
 	})

--- a/s3/mock/bucket.go
+++ b/s3/mock/bucket.go
@@ -10,6 +10,7 @@ import (
 	fmt "fmt"
 	s3 "github.com/jacobsa/aws/s3"
 	oglemock "github.com/jacobsa/oglemock"
+	http "net/http"
 	runtime "runtime"
 	unsafe "unsafe"
 )
@@ -60,6 +61,35 @@ func (m *mockBucket) DeleteObject(p0 string) (o0 error) {
 	// o0 error
 	if retVals[0] != nil {
 		o0 = retVals[0].(error)
+	}
+
+	return
+}
+
+func (m *mockBucket) GetHeader(p0 string) (o0 http.Header, o1 error) {
+	// Get a file name and line number for the caller.
+	_, file, line, _ := runtime.Caller(1)
+
+	// Hand the call off to the controller, which does most of the work.
+	retVals := m.controller.HandleMethodCall(
+		m,
+		"GetHeader",
+		file,
+		line,
+		[]interface{}{p0})
+
+	if len(retVals) != 2 {
+		panic(fmt.Sprintf("mockBucket.GetHeader: invalid return values: %v", retVals))
+	}
+
+	// o0 http.Header
+	if retVals[0] != nil {
+		o0 = retVals[0].(http.Header)
+	}
+
+	// o1 error
+	if retVals[1] != nil {
+		o1 = retVals[1].(error)
 	}
 
 	return

--- a/s3/mock/bucket.go
+++ b/s3/mock/bucket.go
@@ -10,6 +10,7 @@ import (
 	fmt "fmt"
 	s3 "github.com/jacobsa/aws/s3"
 	oglemock "github.com/jacobsa/oglemock"
+	io "io"
 	http "net/http"
 	runtime "runtime"
 	unsafe "unsafe"
@@ -148,6 +149,30 @@ func (m *mockBucket) ListKeys(p0 string) (o0 []string, o1 error) {
 	// o1 error
 	if retVals[1] != nil {
 		o1 = retVals[1].(error)
+	}
+
+	return
+}
+
+func (m *mockBucket) Put(p0 string, p1 io.ReadSeeker) (o0 error) {
+	// Get a file name and line number for the caller.
+	_, file, line, _ := runtime.Caller(1)
+
+	// Hand the call off to the controller, which does most of the work.
+	retVals := m.controller.HandleMethodCall(
+		m,
+		"Put",
+		file,
+		line,
+		[]interface{}{p0, p1})
+
+	if len(retVals) != 1 {
+		panic(fmt.Sprintf("mockBucket.Put: invalid return values: %v", retVals))
+	}
+
+	// o0 error
+	if retVals[0] != nil {
+		o0 = retVals[0].(error)
 	}
 
 	return


### PR DESCRIPTION
extended the bucket api to include GetHeader, to do HEAD requests:

http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectHEAD.html

Going forwards, we'd also like to add the following to enable streaming uploads and downloads:

```
    Get(key string) (*sys_http.Response, err error)
    Put(key string, data io.Reader) (*sys_http.Response, err error)
```

Let us know what you think.
Cheers,

@tedsuo & @phanle
